### PR TITLE
fix: use pagerduty-specific moduleId

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -6,7 +6,7 @@ import { createPagerDutyServiceAction } from "./actions/custom";
 /** @public */
 export const pagerDutyScaffolderActions = createBackendModule({
     pluginId: 'scaffolder',
-    moduleId: 'custom-extensions',
+    moduleId: 'pagerduty-actions',
     register(env) {
         env.registerInit({
             deps: {


### PR DESCRIPTION
### Description

The previous value (custom-extensions) conflicts with the example value from the [backstage documentation for writing custom actions](https://backstage.io/docs/features/software-templates/writing-custom-actions#register-action-with-new-backend-system). This value should be specific to this module.

**Issue number:** N/A

### Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist

- [x] I have performed a self-review of this change
- [x] Changes have been tested
- [ ] Changes are documented
- [x] Changes generate *no new warnings*
- [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/)

If this is a breaking change 👇

- [ ] I have documented the migration process
- [ ] I have implemented necessary warnings (if it can live side by side)

## Acknowledgement

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer:** We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
